### PR TITLE
Drop node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache:
   directories:
     - node_modules
 node_js:
-  - 6
   - 8
   - 9
 after_success:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/styleguidist/mini-html-webpack-plugin",
   "repository": "styleguidist/mini-html-webpack-plugin",
   "engines": {
-    "node": ">=6.9"
+    "node": ">=8.12"
   },
   "devDependencies": {
     "@webpack-contrib/test-utils": "^0.1.2",


### PR DESCRIPTION
Travis running test fail with:

**Node.js: 6**
● Test suite failed to run
SecurityError: localStorage is not available for opaque origins