### PR TITLE
feat: Add support for head and body parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ const config = {
         title: 'Webpack demo',
         // Optional, defaults to `{ lang: 'en' }`
         htmlAttributes: { lang: 'en' },
+        // Optional, any additional HTML attached within <head>
+        head: '',
         // Optional, any additional HTML attached within <body>
         body: '',
         // Optional

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ const config = {
         title: 'Webpack demo',
         // Optional, defaults to `{ lang: 'en' }`
         htmlAttributes: { lang: 'en' },
+        // Optional, any additional HTML attached within <body>
+        body: '',
         // Optional
         cssAttributes: { rel: 'preload' },
         // Optional

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`additional body 1`] = `
+"<!DOCTYPE html>
+  <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <title></title>
+      
+    </head>
+		<body>
+			<div>Demo</div><script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    </body>
+  </html>"
+`;
+
 exports[`custom chunks 1`] = `
 "<!DOCTYPE html>
   <html lang=\\"en\\">
@@ -8,8 +22,8 @@ exports[`custom chunks 1`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"runtime~index.js\\"></script><script src=\\"index.js\\"></script>
+		<body>
+			<script src=\\"runtime~index.js\\"></script><script src=\\"index.js\\"></script>
     </body>
   </html>"
 `;
@@ -22,8 +36,8 @@ exports[`custom chunks 2`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"runtime~another.js\\"></script><script src=\\"another.js\\"></script>
+		<body>
+			<script src=\\"runtime~another.js\\"></script><script src=\\"another.js\\"></script>
     </body>
   </html>"
 `;
@@ -36,8 +50,8 @@ exports[`custom filename 1`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+		<body>
+			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -50,8 +64,8 @@ exports[`custom js attribute 1`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"runtime~main.js\\" defer=\\"defer\\"></script><script src=\\"main.js\\" defer=\\"defer\\"></script>
+		<body>
+			<script src=\\"runtime~main.js\\" defer=\\"defer\\"></script><script src=\\"main.js\\" defer=\\"defer\\"></script>
     </body>
   </html>"
 `;
@@ -64,8 +78,8 @@ exports[`custom lang 1`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+		<body>
+			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -78,8 +92,8 @@ exports[`custom publicPath 1`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"pizza/runtime~main.js\\"></script><script src=\\"pizza/main.js\\"></script>
+		<body>
+			<script src=\\"pizza/runtime~main.js\\"></script><script src=\\"pizza/main.js\\"></script>
     </body>
   </html>"
 `;
@@ -94,8 +108,8 @@ exports[`custom title 1`] = `
       <title>Pizza</title>
       
     </head>
-    <body>
-      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+		<body>
+			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -108,8 +122,8 @@ exports[`default options 1`] = `
       <title></title>
       
     </head>
-    <body>
-      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+		<body>
+			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -8,8 +8,8 @@ exports[`additional body 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<div>Demo</div><script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <body>
+      <div>Demo</div><script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -22,8 +22,8 @@ exports[`additional head 1`] = `
       <title></title>
       <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
     </head>
-		<body>
-			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <body>
+      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -36,8 +36,8 @@ exports[`custom chunks 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"runtime~index.js\\"></script><script src=\\"index.js\\"></script>
+    <body>
+      <script src=\\"runtime~index.js\\"></script><script src=\\"index.js\\"></script>
     </body>
   </html>"
 `;
@@ -50,8 +50,8 @@ exports[`custom chunks 2`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"runtime~another.js\\"></script><script src=\\"another.js\\"></script>
+    <body>
+      <script src=\\"runtime~another.js\\"></script><script src=\\"another.js\\"></script>
     </body>
   </html>"
 `;
@@ -64,8 +64,8 @@ exports[`custom filename 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <body>
+      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -78,8 +78,8 @@ exports[`custom js attribute 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"runtime~main.js\\" defer=\\"defer\\"></script><script src=\\"main.js\\" defer=\\"defer\\"></script>
+    <body>
+      <script src=\\"runtime~main.js\\" defer=\\"defer\\"></script><script src=\\"main.js\\" defer=\\"defer\\"></script>
     </body>
   </html>"
 `;
@@ -92,8 +92,8 @@ exports[`custom lang 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <body>
+      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -106,8 +106,8 @@ exports[`custom publicPath 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"pizza/runtime~main.js\\"></script><script src=\\"pizza/main.js\\"></script>
+    <body>
+      <script src=\\"pizza/runtime~main.js\\"></script><script src=\\"pizza/main.js\\"></script>
     </body>
   </html>"
 `;
@@ -122,8 +122,8 @@ exports[`custom title 1`] = `
       <title>Pizza</title>
       
     </head>
-		<body>
-			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <body>
+      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;
@@ -136,8 +136,8 @@ exports[`default options 1`] = `
       <title></title>
       
     </head>
-		<body>
-			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    <body>
+      <script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
     </body>
   </html>"
 `;

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -14,6 +14,20 @@ exports[`additional body 1`] = `
   </html>"
 `;
 
+exports[`additional head 1`] = `
+"<!DOCTYPE html>
+  <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <title></title>
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    </head>
+		<body>
+			<script src=\\"runtime~main.js\\"></script><script src=\\"main.js\\"></script>
+    </body>
+  </html>"
+`;
+
 exports[`custom chunks 1`] = `
 "<!DOCTYPE html>
   <html lang=\\"en\\">

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function defaultTemplate({
 	htmlAttributes = {
 		lang: 'en',
 	},
+	body = '',
 	cssAttributes = {},
 	jsAttributes = {},
 }) {
@@ -105,8 +106,8 @@ function defaultTemplate({
       <title>${title}</title>
       ${cssTags}
     </head>
-    <body>
-      ${jsTags}
+		<body>
+			${body}${jsTags}
     </body>
   </html>`;
 }

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function defaultTemplate({
 	htmlAttributes = {
 		lang: 'en',
 	},
+	head = '',
 	body = '',
 	cssAttributes = {},
 	jsAttributes = {},
@@ -104,7 +105,7 @@ function defaultTemplate({
     <head>
       <meta charset="UTF-8">
       <title>${title}</title>
-      ${cssTags}
+      ${head}${cssTags}
     </head>
 		<body>
 			${body}${jsTags}

--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ function defaultTemplate({
       <title>${title}</title>
       ${head}${cssTags}
     </head>
-		<body>
-			${body}${jsTags}
+    <body>
+      ${body}${jsTags}
     </body>
   </html>`;
 }

--- a/test.js
+++ b/test.js
@@ -63,6 +63,14 @@ test('custom lang', () => {
 	});
 });
 
+test('additional body', () => {
+	return compiler({}, getConfig({ context: { body: '<div>Demo</div>' } })).then(
+		result => {
+			expect(result.compilation.assets['index.html']._value).toMatchSnapshot();
+		}
+	);
+});
+
 test('custom js attribute', () => {
 	return compiler(
 		{},

--- a/test.js
+++ b/test.js
@@ -63,6 +63,20 @@ test('custom lang', () => {
 	});
 });
 
+test('additional head', () => {
+	return compiler(
+		{},
+		getConfig({
+			context: {
+				head:
+					'<meta name="viewport" content="width=device-width, initial-scale=1.0" />',
+			},
+		})
+	).then(result => {
+		expect(result.compilation.assets['index.html']._value).toMatchSnapshot();
+	});
+});
+
 test('additional body', () => {
 	return compiler({}, getConfig({ context: { body: '<div>Demo</div>' } })).then(
 		result => {


### PR DESCRIPTION
I realized the same is useful for `head` as sometimes you need to inject for example custom `meta` tags.

Closes #19.