### PR TITLE
fix: Drop default export to fix CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install mini-html-webpack-plugin
 ```
 
 ```javascript
-const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
+const { MiniHtmlWebpackPlugin } = require('mini-html-webpack-plugin');
 
 const config = {
   plugins: [
@@ -57,7 +57,7 @@ It's possible to use `MiniHtmlWebpackPlugin` to develop sites with multiple page
 To achieve this, you'll have to define `entry` against each the code for each page and define `MiniHtmlWebpackPlugin` to match them. In practice you might want to abstract this pairing but to give you the full idea, consider the example below.
 
 ```javascript
-const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
+const { MiniHtmlWebpackPlugin } = require('mini-html-webpack-plugin');
 
 const config = {
   entry: {
@@ -81,7 +81,7 @@ const config = {
 
 ```javascript
 const minify = require('html-minifier').minify;
-const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
+const { MiniHtmlWebpackPlugin } = require('mini-html-webpack-plugin');
 
 const config = {
   plugins: [
@@ -105,12 +105,12 @@ Or define a template function to generate your own code.
 The template function may return a string or a `Promise` resolving to a string.
 
 ```js
-const MiniHtmlWebpackPlugin = require('mini-html-webpack-plugin');
 const {
+  MiniHtmlWebpackPlugin,
   generateAttributes,
   generateCSSReferences,
   generateJSReferences
-} = MiniHtmlWebpackPlugin;
+} = require('mini-html-webpack-plugin');
 
 const config = {
   plugins: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ class MiniHtmlWebpackPlugin implements webpack.Plugin {
 }
 
 export {
-	MiniHtmlWebpackPlugin as default,
+	MiniHtmlWebpackPlugin,
 	defaultTemplate,
 	generateAttributes,
 	generateCSSReferences,

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,5 +1,5 @@
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import MiniHtmlWebpackPlugin from '../src';
+import { MiniHtmlWebpackPlugin } from '../src';
 import compiler from '@webpack-contrib/test-utils';
 
 const getConfig = (options: {}, config: { title?: string } = {}) =>


### PR DESCRIPTION
Sadly this is a breaking change but no can do.

Related: https://github.com/microsoft/TypeScript/issues/2719.