### PR TITLE
fix(generateJSAttributes): Allow attributes to be undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,8 +102,12 @@ function generateJSReferences({
 }: {
 	files: string[];
 	publicPath: string;
-	attributes: Attributes;
+	attributes: Attributes | undefined;
 }): string {
+	if (!attributes) {
+		return '';
+	}
+
 	return files
 		.map(
 			(file) =>


### PR DESCRIPTION
This is the same as for CSS as we cannot guarantee webpack is generating the files.